### PR TITLE
Correct bug for mb_access_token(install=FALSE)

### DIFF
--- a/R/accounts.R
+++ b/R/accounts.R
@@ -66,7 +66,7 @@ mb_access_token <- function(token, overwrite = FALSE, install = FALSE) {
     return(token)
   } else {
     message("To install your access token for use in future sessions, run this function with `install = TRUE`.")
-    Sys.setenv(type = token)
+    do.call(Sys.setenv, stats::setNames(list(token), type))
   }
 }
 


### PR DESCRIPTION
As it stands, this will just set the environment variable `type`, not `MAPBOX_PUBLIC_TOKEN` (e.g.).